### PR TITLE
Adds lograge gem for condensed logging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,4 +38,5 @@ group :production do
   gem "pg"
   gem "newrelic_rpm"
   gem "honeybadger"
+  gem "lograge"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,10 @@ GEM
       thor (>= 0.14, < 2.0)
     json (1.7.7)
     listen (0.7.3)
+    lograge (0.2.2)
+      actionpack (>= 3)
+      activesupport (>= 3)
+      railties (>= 3)
     lumberjack (1.0.2)
     mail (2.4.4)
       i18n (>= 0.4.0)
@@ -212,6 +216,7 @@ DEPENDENCIES
   heroku_resque_autoscaler (~> 0.1.0)
   honeybadger
   jquery-rails
+  lograge
   microformats2 (= 2.0.0.pre1)
   newrelic_rpm
   pg

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -4,6 +4,9 @@ Configurator::Application.configure do
   # Code is not reloaded between requests
   config.cache_classes = true
 
+  # Adds condensed logging
+  config.lograge.enabled = true
+
   # Full error reports are disabled and caching is turned on
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true


### PR DESCRIPTION
Pivotal Tracker story: https://www.pivotaltracker.com/story/show/66568320

Have Papertrail filter noise, such as requests for static assets. http://blog.papertrailapp.com/more-signal-less-noise-with-simple-free-log-filtering/

Denser logging. Many Web frameworks (including Rails) are very verbose. Here's how to make Rails logs more useful and denser in 2 minutes. http://help.papertrailapp.com/kb/configuration/controlling-verbosity

Related:
https://github.com/g5search/g5-content-management-system/pull/238
https://github.com/g5search/g5-client-app-creator/pull/26
https://github.com/G5/g5-hub/pull/24
https://github.com/G5/g5-layout-garden/pull/16
https://github.com/g5search/g5-theme-garden/pull/67
https://github.com/G5/g5-widget-garden/pull/197
https://github.com/G5/g5-pricing-and-availability-service/pull/30
https://github.com/G5/g5-phone-number-service/pull/13
