### PR TITLE
Add app definitions for CLS/CXM/DSH

### DIFF
--- a/config/app_definitions.yml.erb
+++ b/config/app_definitions.yml.erb
@@ -40,3 +40,8 @@
   human_name: "Client Experience Management"
   prefix: "cxm"
   repo_url: "git@github.com:g5search/g5-cxm.git"
+-
+  kind: "client-dashboard"
+  human_name: "Client Dashboard"
+  prefix: "dsh"
+  repo_url: "git@github.com:g5search/g5-dashboard.git"

--- a/spec/models/entry_spec.rb
+++ b/spec/models/entry_spec.rb
@@ -38,7 +38,7 @@ describe Entry do
     end
     it "creates four RemoteApps with appropriate attrs" do
       expect { Entry.find_or_create_from_hentry(@entry) }.to(
-        change(RemoteApp, :count).by(6))
+        change(RemoteApp, :count).by(7))
       expect(Entry.last.remote_apps.last.organization).to eq("Test-Organization")
     end
   end


### PR DESCRIPTION
One problem I can see here is that those are closed source apps. It's not exposing anything private but somebody from the outside can't really fire it up anymore. I'm not sure what the best solution is, but I do know that we have enough code to write around this at the moment that I don't really want to tackle it right now.
