### PR TITLE
add news and events to client constipations

### DIFF
--- a/config/app_definitions.yml.erb
+++ b/config/app_definitions.yml.erb
@@ -45,3 +45,8 @@
   human_name: "Client Dashboard"
   prefix: "dsh"
   repo_url: "git@github.com:g5search/g5-dashboard.git"
+-
+  kind: "news-and-events-service"
+  human_name: "News and Events Service"
+  prefix: "nae"
+  repo_url: "git@github.com:G5/g5-news-and-events-service.git"

--- a/spec/models/entry_spec.rb
+++ b/spec/models/entry_spec.rb
@@ -38,7 +38,7 @@ describe Entry do
     end
     it "creates four RemoteApps with appropriate attrs" do
       expect { Entry.find_or_create_from_hentry(@entry) }.to(
-        change(RemoteApp, :count).by(7))
+        change(RemoteApp, :count).by(8))
       expect(Entry.last.remote_apps.last.organization).to eq("Test-Organization")
     end
   end


### PR DESCRIPTION
New service that creates and publishes a feed of news and events needs to be added to client constellations.