### PR TITLE
Targeted updates

### DIFF
--- a/app/assets/javascripts/instructions.coffee
+++ b/app/assets/javascripts/instructions.coffee
@@ -1,32 +1,39 @@
 $ = jQuery
+
+showSelect = (selector) ->
+  $(selector).show()
+  $(selector + " select").removeAttr("disabled")
+
+hideSelect = (selector) ->
+  $(selector).hide()
+  $(selector + " select").attr("disabled", "disabled")
+
 $ ->
-  $targetAppsSelect = $(".js-target_apps select")
-  $targetAppsOptgroups = $targetAppsSelect.children()
-  # when target app type changes
+  # at this point, the target app select widget has options for every app
+  targetAppOptions = $(".js-target_apps select").children()
+
+  # returns a subset of target apps above based on target app kind
+  optionsFor = (targetAppKind) ->
+    targetAppOptions.filter('optgroup[label$="' + targetAppKind + '"]')
+
+  # selecting a different target app kind will modify the form
   $(".js-target_app_kind").change ->
+    # hide specific form widgets
+    hideSelect(".js-target_apps");
+    hideSelect(".js-remote_app");
+    hideSelect(".js-updated_app_kinds");
+
     # find selected target app kind
     targetAppKind = $(".js-target_app_kind option:selected").attr("value")
-    if targetAppKind == ""
-      # initially, hide target apps and remote app
-      $(".js-target_apps").hide()
-      $(".js-target_apps select").attr("disabled", "disabled")
-      $(".js-remote_app").hide()
-      $(".js-remote_app select").attr("disabled", "disabled")
-    else
-      # filter target app options
-      $targetAppsSelect.empty()
-      blank = $targetAppsOptgroups.filter('option[value=""]')
-      matching_optgroup_options = $targetAppsOptgroups.filter('optgroup[label$="' + targetAppKind + '"]')
-      $targetAppsSelect.append(blank).append(matching_optgroup_options).find('option').clone()
-      # display target apps
-      $(".js-target_apps").show()
-      $(".js-target_apps select").removeAttr("disabled")
-      # if client-app-creator then show remote app else hide
-      if targetAppKind == "client-app-creator"
-        $(".js-remote_app").show()
-        $(".js-remote_app select").removeAttr("disabled")
-      else
-        $(".js-remote_app").hide()
-        $(".js-remote_app select").attr("disabled", "disabled")
-  # trigger appropriated hide/shows on page load
+
+    # only show target apps which match target app kind
+    $(".js-target_apps select").empty()
+    $(".js-target_apps select").append optionsFor(targetAppKind)
+
+    # show form widgets specific to this target app
+    showSelect(".js-target_apps") unless targetAppKind == ""
+    showSelect(".js-remote_app") if targetAppKind == "client-app-creator"
+    showSelect(".js-updated_app_kinds") if targetAppKind == "client-app-updater"
+
+  # manually trigger initial form setup
   $(".js-target_app_kind").change()

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,3 +21,8 @@
   height:500px;
   width:500px;
 }
+
+#instruction_updated_app_kinds {
+  height:200px;
+  width:250px;
+}

--- a/app/controllers/instructions_controller.rb
+++ b/app/controllers/instructions_controller.rb
@@ -24,6 +24,6 @@ class InstructionsController < ApplicationController
 
   private
     def instruction_params
-      params.fetch(:instruction, {}).permit(:target_app_kind, :remote_app_id, :body, target_app_ids: [])
+      params.fetch(:instruction, {}).permit(:target_app_kind, :remote_app_id, :body, target_app_ids: [], updated_app_kinds: [])
     end
 end

--- a/app/models/app_definition.rb
+++ b/app/models/app_definition.rb
@@ -8,6 +8,10 @@ class AppDefinition
     @all_kinds ||= ALL.map(&:kind)
   end
 
+  def self.updatable_kinds
+    all_kinds.reject {|a| a.in? ["client-app-creator", "client-app-creator-deployer", "client-app-updater"] }
+  end
+
   def self.for_kind(kind)
     AppDefinition::ALL.detect { |a| a.kind == kind }
   end

--- a/app/models/app_definition.rb
+++ b/app/models/app_definition.rb
@@ -9,7 +9,7 @@ class AppDefinition
   end
 
   def self.updatable_kinds
-    all_kinds.reject {|a| a.in? ["client-app-creator", "client-app-creator-deployer", "client-app-updater"] }
+    ALL.map(&:prefix).reject! {|a| a.in? ["cau", "nil"]}
   end
 
   def self.for_kind(kind)

--- a/app/models/instruction.rb
+++ b/app/models/instruction.rb
@@ -21,6 +21,7 @@ class Instruction < ActiveRecord::Base
 
   # webhooks make things speedy
   after_save :async_webhook_target_apps
+  before_validation {|i| i.updated_app_kinds.reject!(&:empty?) }
 
   def created_at_computer_readable
     created_at.utc.to_s(:computer)

--- a/app/models/instruction.rb
+++ b/app/models/instruction.rb
@@ -21,7 +21,9 @@ class Instruction < ActiveRecord::Base
 
   # webhooks make things speedy
   after_save :async_webhook_target_apps
-  before_validation {|i| i.updated_app_kinds.reject!(&:empty?) }
+  before_validation do |i|
+    i.updated_app_kinds.select! { |k| k.in?(AppDefinition.updatable_kinds) }
+  end
 
   def created_at_computer_readable
     created_at.utc.to_s(:computer)

--- a/app/views/entries/_entry.html.erb
+++ b/app/views/entries/_entry.html.erb
@@ -49,6 +49,16 @@
           </li>
         <% end %>
       </ul>
+      <% if instruction.updated_app_kinds.present? %>
+        <h4>Updated Apps</h4>
+        <ul>
+          <% instruction.updated_app_kinds.each do |kind| %>
+            <li class="p-g5-updated-app-kind h-card">
+              <%= link_to kind, nil, class: "p-g5-kind" %>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
       <% if instruction.remote_app.present? %>
         <h4>App</h4>
         <div class="p-g5-app h-card">

--- a/app/views/instructions/new.html.erb
+++ b/app/views/instructions/new.html.erb
@@ -25,6 +25,13 @@
       </div>
       <span class="help-block">This is the app that the instruction will be performed on.</span>
     </div>
+    <div class="control-group js-updated_app_kinds">
+      <%= f.label :target_app_kind, "Updated App Kinds", class: "control-label" %>
+      <div class="controls">
+        <%= f.select :updated_app_kinds, AppDefinition.updatable_kinds, {}, multiple: true %>
+      </div>
+      <span class="help-block">This is the kind of app that will updated.</span>
+    </div>
     <div class="control-group">
       <div class="controls">
         <%= f.submit class: "btn btn-success" %></p>

--- a/db/migrate/20150427201404_add_updated_app_kinds_to_instruction.rb
+++ b/db/migrate/20150427201404_add_updated_app_kinds_to_instruction.rb
@@ -1,0 +1,5 @@
+class AddUpdatedAppKindsToInstruction < ActiveRecord::Migration
+  def change
+    add_column :instructions, :updated_app_kinds, :string, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140819191024) do
+ActiveRecord::Schema.define(version: 20150427201404) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
 
   create_table "entries", force: true do |t|
     t.string   "uid"
@@ -33,14 +36,15 @@ ActiveRecord::Schema.define(version: 20140819191024) do
     t.datetime "updated_at"
   end
 
-  add_index "g5_authenticatable_users", ["email"], name: "index_g5_authenticatable_users_on_email", unique: true
-  add_index "g5_authenticatable_users", ["provider", "uid"], name: "index_g5_authenticatable_users_on_provider_and_uid", unique: true
+  add_index "g5_authenticatable_users", ["email"], name: "index_g5_authenticatable_users_on_email", unique: true, using: :btree
+  add_index "g5_authenticatable_users", ["provider", "uid"], name: "index_g5_authenticatable_users_on_provider_and_uid", unique: true, using: :btree
 
   create_table "instructions", force: true do |t|
     t.integer  "remote_app_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "target_app_kind"
+    t.string   "updated_app_kinds", default: [], array: true
   end
 
   create_table "instructions_target_apps", force: true do |t|

--- a/spec/models/app_definition_spec.rb
+++ b/spec/models/app_definition_spec.rb
@@ -24,6 +24,15 @@ describe AppDefinition do
     it { should include("content-management-system") }
   end
 
+  describe ".updatable_kinds" do
+    subject { AppDefinition.updatable_kinds }
+
+    it { should_not be_empty }
+    it { should include("cms") }
+    it { should_not include("cau") }
+    it { should_not include(nil) }
+  end
+
   describe ".for_kind" do
     subject { AppDefinition.for_kind(kind) }
 

--- a/spec/models/instruction_spec.rb
+++ b/spec/models/instruction_spec.rb
@@ -14,7 +14,8 @@ describe Instruction do
     @instruction = Instruction.create!(
       target_app_kind: @client_app_creator.kind,
       target_app_ids: [@client_app_creator.id],
-      remote_app_id: @client_hub.id
+      remote_app_id: @client_hub.id,
+      updated_app_kinds: [nil, "", "cau", "cms"]
     )
   end
   subject { @instruction }
@@ -23,6 +24,7 @@ describe Instruction do
   its(:target_app_kind) { should be_present }
   its(:target_app_ids) { should be_present }
   its(:remote_app_id) { should be_present }
+  its(:updated_app_kinds) { should eq(["cms"]) }
 
   describe "#name" do
     subject { Instruction.new(target_app_kind: kind).name }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/91721840

I validated this by deploying to the apps in my g5-testing-one org, where there is an alternative hub/configurator/creator/updater infrastructure.  The CAU logs indicate which apps it is trying to update, even if the targets are already up-to-date.  I followed the logs before and after these changes to validate that the newer version only updates apps specified in the configurator form.