### PR TITLE
Stop spinning up CAUs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 2.1.5
 script:
   - RAILS_ENV=test bundle exec rake db:schema:load --trace
+  - RAILS_ENV=test bundle exec rake db:migrate
   - bundle exec rspec
 before_script:
   - cp config/database.travis.yml config/database.yml

--- a/config/app_definitions.yml.erb
+++ b/config/app_definitions.yml.erb
@@ -16,11 +16,6 @@
   prefix: "cms"
   repo_url: "git@github.com:G5/g5-content-management-system.git"
 -
-  kind: "client-app-updater"
-  human_name: "Client App Updater"
-  prefix: "cau"
-  repo_url: "git@github.com:G5/g5-sibling-deployer.git"
--
   kind: "client-lead-service"
   human_name: "Client Lead Service"
   prefix: "cls"

--- a/db/migrate/20160114002218_delete_cau.rb
+++ b/db/migrate/20160114002218_delete_cau.rb
@@ -1,0 +1,5 @@
+class DeleteCau < ActiveRecord::Migration
+  def change
+    RemoteApp.where(kind: "client-app-updater").destroy_all
+  end
+end

--- a/spec/models/entry_spec.rb
+++ b/spec/models/entry_spec.rb
@@ -36,9 +36,9 @@ describe Entry do
       expect { Entry.find_or_create_from_hentry(@entry) }.to(
         change(Entry, :count).by(1))
     end
-    it "creates four RemoteApps with appropriate attrs" do
+    it "creates two RemoteApps with appropriate attrs" do
       expect { Entry.find_or_create_from_hentry(@entry) }.to(
-        change(RemoteApp, :count).by(3))
+        change(RemoteApp, :count).by(2))
       expect(Entry.last.remote_apps.last.organization).to eq("Test-Organization")
     end
   end

--- a/spec/models/remote_app_spec.rb
+++ b/spec/models/remote_app_spec.rb
@@ -104,7 +104,7 @@ describe RemoteApp do
   describe "#siblings" do
     before :each do
       @sibling = RemoteApp.create!(
-        kind: "client-app-updater",
+        kind: "client-lead-service",
         client_name: "mock client",
         client_uid: @app.client_uid
       )


### PR DESCRIPTION
Testing:
 * Created a new client on t1-configurator master, three apps are created: cau, cms, cls
 * Deployed this change and create another client, only two apps created: cms, cls