### PR TITLE
Updates heroku app name formatter gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,22 @@
 language: ruby
 rvm:
-  - 2.1.5
+- 2.1.5
 script:
-  - RAILS_ENV=test bundle exec rake db:schema:load --trace
-  - RAILS_ENV=test bundle exec rake db:migrate
-  - bundle exec rspec
+- RAILS_ENV=test bundle exec rake db:schema:load --trace
+- RAILS_ENV=test bundle exec rake db:migrate
+- bundle exec rspec
 before_script:
-  - cp config/database.travis.yml config/database.yml
-  - psql -c 'create database g5_configurator_test;' -U postgres
+- cp config/database.travis.yml config/database.yml
+- psql -c 'create database g5_configurator_test;' -U postgres
 notifications:
   campfire:
     rooms:
       secure: aI6dyzNBa2lolmisnfJzW3tQn+6p3Fa6OT1Tf2SCI7pF5cgFot8Q2fh6rKWOZBPbjIs1iaJsAc8qcnajJkntuqQAk0NdgStzNvECjEdCDmmrwfBsVLbh58GosuQxCsiTDQs56oWTClQbYP025V2wr5U9qXy9KU9gKK5lS4tGMXg=
     template:
-          - "%{repository}#%{build_number} %{message} (%{branch} - %{commit} : %{author}) Change view : %{compare_url} Build details : %{build_url}"
+    - "%{repository}#%{build_number} %{message} (%{branch} - %{commit} : %{author})
+      Change view : %{compare_url} Build details : %{build_url}"
     on_success: change
     on_failure: always
+env:
+  matrix:
+    secure: CN+ZEBPi3OsXWUjf57gFSI9M6zU2qDrl3+WvFH1uW43UH6Np0moRK0HAtE/qeIbZy9SVLtUnAUpHz5Kh2lEURXz1BnOSSsaXOA7MU7k/hGLYbwgPG+sZKqIK+9zuJdjqZZ3f+uwpk6L6icWml+V8pDZFCIVfD42+UpRiDG7CnuQ=

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ gem 'sass-rails',   '~> 4.0.0'
 gem 'coffee-rails', '~> 4.0.0'
 gem 'uglifier', '>= 1.0.3'
 gem 'httparty'
-gem 'g5_heroku_app_name_formatter'
 
 group :development, :test do
   gem 'resque_spec'
@@ -46,4 +45,8 @@ group :production do
   gem 'newrelic_rpm'
   gem 'honeybadger'
   gem 'lograge'
+end
+
+source "https://#{ENV['FURY_AUTH']}@gem.fury.io/g5dev/" do
+  gem 'g5_heroku_app_name_formatter'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,6 @@
 GEM
   remote: https://rubygems.org/
+  remote: https://gem.fury.io/g5dev/
   specs:
     actionmailer (4.1.12)
       actionpack (= 4.1.12)
@@ -99,7 +100,7 @@ GEM
       configlet (~> 2.1)
       modelish (~> 0.3)
       oauth2
-    g5_heroku_app_name_formatter (0.0.2)
+    g5_heroku_app_name_formatter (0.3.6)
     guard (2.12.5)
       formatador (>= 0.2.4)
       listen (~> 2.7)
@@ -317,7 +318,7 @@ DEPENDENCIES
   factory_girl_rails
   foreman
   g5_authenticatable
-  g5_heroku_app_name_formatter
+  g5_heroku_app_name_formatter!
   guard-rspec
   heroku_resque_autoscaler (~> 0.1.0)
   honeybadger
@@ -341,3 +342,6 @@ DEPENDENCIES
   unicorn
   webhook
   webmock
+
+BUNDLED WITH
+   1.10.6


### PR DESCRIPTION
The `g5_heroku_app_name_formatter` gem is being moved to a private repo under the `g5search` org. It is also being move from RubyGems to GemFury.  This will require some repo's, like this one, to have a Gemfury source block so the gem is bundled from the correct package.

Edit:  Used info from [TravisCI Docs](https://docs.travis-ci.com/user/environment-variables/#Encrypting-Variables-Using-a-Public-Key) to encrypt gemfury key so that the build passes without exposing the key.